### PR TITLE
fix: include built deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,12 @@
     "tw-animate-css": "^1.3.6",
     "typescript": "^5.8.3",
     "vite-tsconfig-paths": "^5.1.4"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "@tailwindcss/oxide",
+      "esbuild"
+    ]
   }
 }


### PR DESCRIPTION
- Adds `pnpm.onlyBuiltDependencies` to `package.json` for building native deps