### PR TITLE
fix: add asChild to navigation link to fix <a> nesting bug

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -15,19 +15,19 @@ export function Navbar() {
         <TopNavigationMenuList className='px-4 space-x-2 w-screen h-12'>
           <Separator orientation='vertical' className='bg-neutral-800' />
           <TopNavigationMenuItem>
-            <TopNavigationMenuLink className='font-semibold hover:border-transparent'>
+            <TopNavigationMenuLink className='font-semibold hover:border-transparent focus:bg-inherit focus:text-inherit' asChild>
               <Link to='/' >crdb.net</Link>
             </TopNavigationMenuLink>
           </TopNavigationMenuItem>
           <Separator orientation='vertical' className='bg-neutral-800' />
           <TopNavigationMenuItem>
-            <TopNavigationMenuLink className='' active={inEvents}>
+            <TopNavigationMenuLink className='focus:bg-inherit focus:text-inherit' active={inEvents} asChild>
               <Link to='/events' className=''>Events</Link>
             </TopNavigationMenuLink>
           </TopNavigationMenuItem>
           <Separator orientation='vertical' className='bg-neutral-800' />
           <TopNavigationMenuItem>
-            <TopNavigationMenuLink className='' active={inRankings}>
+            <TopNavigationMenuLink className='focus:bg-inherit focus:text-inherit' active={inRankings} asChild>
               <Link to='/rankings' className='font-display'>Rankings</Link>
             </TopNavigationMenuLink>
           </TopNavigationMenuItem>


### PR DESCRIPTION
- Fixes a bug where a Tanstack `Link` was being nested inside a `TopNavigationMenuLink`, which threw the bug shown in the below image.
<img width="1920" height="1112" alt="image" src="https://github.com/user-attachments/assets/ba57acef-4346-406b-b931-74e51532ca8c" />
